### PR TITLE
Add support for cycle dependencies

### DIFF
--- a/app/src/main/java/ru/hh/multimodule/App.kt
+++ b/app/src/main/java/ru/hh/multimodule/App.kt
@@ -14,7 +14,7 @@ internal class App : Application() {
     }
 
     private fun initTp() {
-        val tpConfig = Configuration().preventMultipleRootScopes()
+        val tpConfig = Configuration.forDevelopment().preventMultipleRootScopes()
         Toothpick.setConfiguration(tpConfig)
 
         // Используем rootScope Toothpick-а в качестве AppScope

--- a/app/src/main/java/ru/hh/multimodule/deps/FeatureDepsModule.kt
+++ b/app/src/main/java/ru/hh/multimodule/deps/FeatureDepsModule.kt
@@ -4,6 +4,8 @@ import ru.hh.di.FeatureFacade
 import ru.hh.photo_picker.api.PhotoPickerFacade
 import ru.hh.profile.api.ProfileFacade
 import toothpick.config.Module
+import toothpick.ktp.binding.bind
+import kotlin.reflect.KClass
 
 
 /**
@@ -12,18 +14,19 @@ import toothpick.config.Module
 internal class FeatureDepsModule : Module() {
 
     init {
-        bindFeatureDeps(ProfileFacade(), ProfileDepsImpl::class.java)
-        bindFeatureDeps(PhotoPickerFacade(), PhotoPickerDepsImpl::class.java)
+        bindFeatureDeps(ProfileFacade(), ProfileDepsImpl::class)
+        bindFeatureDeps(PhotoPickerFacade(), PhotoPickerDepsImpl::class)
     }
 
-    private fun <Deps, Api, DepsImpl : Deps> bindFeatureDeps(
-        featureFacade: FeatureFacade<Deps, Api>, depsImpl: Class<DepsImpl>
+    private inline fun <reified Deps : Any, Api : Any, reified DepsImpl : Deps, reified TFeatureFacade : FeatureFacade<Deps, Api>> bindFeatureDeps(
+        featureFacade: TFeatureFacade,
+        depsImpl: KClass<DepsImpl>
     ) {
         // FeatureFacade -- абстракция над Api + Deps фичемодуля
         // Задаем связь Deps фичемодуля с DepsImpl и предоставляем Api фичемодуля
 
-        bind(featureFacade.depsClass).to(depsImpl).singleton()
-        bind(featureFacade.apiClass).toProviderInstance { featureFacade.api }.providesSingleton()
+        bind<Deps>().toClass(depsImpl).singleton()
+        bind<TFeatureFacade>().toInstance(featureFacade)
     }
 
 }

--- a/app/src/main/java/ru/hh/multimodule/deps/PhotoPickerDepsImpl.kt
+++ b/app/src/main/java/ru/hh/multimodule/deps/PhotoPickerDepsImpl.kt
@@ -1,8 +1,11 @@
 package ru.hh.multimodule.deps
 
 import ru.hh.photo_picker.api.PhotoPickerDeps
+import ru.hh.profile.api.ProfileFacade
 import toothpick.InjectConstructor
 
-
 @InjectConstructor
-internal class PhotoPickerDepsImpl : PhotoPickerDeps
+internal class PhotoPickerDepsImpl(
+    // Демонстрация того, что циклические зависимости работают
+    private val profileFeature: ProfileFacade
+) : PhotoPickerDeps

--- a/app/src/main/java/ru/hh/multimodule/deps/ProfileDepsImpl.kt
+++ b/app/src/main/java/ru/hh/multimodule/deps/ProfileDepsImpl.kt
@@ -3,16 +3,18 @@ package ru.hh.multimodule.deps
 import androidx.fragment.app.Fragment
 import io.reactivex.rxjava3.core.Observable
 import ru.hh.photo_picker.PhotoPickerArgs
-import ru.hh.photo_picker.api.PhotoPickerApi
+import ru.hh.photo_picker.api.PhotoPickerFacade
 import ru.hh.profile.api.ProfileDeps
 import toothpick.InjectConstructor
 
-
 @InjectConstructor
 internal class ProfileDepsImpl(
-    // для реализации зависимостей фичемодуля, может понадобиться Api другого фичемодуля
-    private val photoPickerApi: PhotoPickerApi
+    // для реализации зависимостей фичемодуля, может понадобиться FeatureFacade другой фичи.
+    // подставляем фасад вместо api, чтобы не иметь циклических зависимостей
+    photoPickerFacade: PhotoPickerFacade
 ) : ProfileDeps {
+
+    private val photoPickerApi by photoPickerFacade.lazyApi
 
     override fun photoPickerFragment(profileId: String): Fragment =
         photoPickerApi.photoPickerFragment(PhotoPickerArgs((profileId)))

--- a/core/di/src/main/java/ru/hh/di/FeatureFacade.kt
+++ b/core/di/src/main/java/ru/hh/di/FeatureFacade.kt
@@ -52,4 +52,10 @@ open class FeatureFacade<Deps, Api>(
     val api: Api
         get() = featureScope.getInstance(apiClass)
 
+    /**
+     * Lazy обёртка над api, чтобы не обращаться в Di каждый раз для получения api
+     */
+    val lazyApi: Lazy<Api>
+        get() = lazy { api }
+
 }


### PR DESCRIPTION
# В текущей реализации есть проблемы

### Проверки циклических зависимостей Toothpick

В данный момент для корректной работы связки модулей нужно отключать правило проверки циклов у туспика, а именно нас интересует RuntimeCheckOnConfiguration, которое включается например через Configuration.forDevelopment() 

```kotlin
                  =======================
                 ||                     ||
                 \/                     ||
ru.hh.photo_picker.api.PhotoPickerApi   ||
                 ||                     ||
                  =======================
```

### Невозможность использовать циклические зависимости для фичей

При текущей реализации мы получаем циклическую зависимость для Toothpick при зависимости фичей друг на друга. В этом можно убедиться добавив в конструктор PhotoPickerDepsImpl аргумент profileApi: ProfileApi

```kotlin
internal class PhotoPickerDepsImpl(
    private val profileApi: ProfileApi
) : PhotoPickerDeps
```

Мы получаем циклическу зависимость 

ProfieleDeps → PhotoPickerApi → PhotoPickerDeps → ProfieleApiDeps

```kotlin
                          =======================
                         ||                     ||
                         \/                     ||
            ru.hh.profile.api.ProfileApi        ||
                         ||                     ||
            ru.hh.profile.api.ProfileDeps       ||
                         ||                     ||
        ru.hh.photo_picker.api.PhotoPickerApi   ||
                         ||                     ||
       ru.hh.photo_picker.api.PhotoPickerDeps   ||
                         ||                     ||
                          =======================
```

# Как это решать?

1. Не хранить Api в родительском скоупе, для этого есть скоуп фичи + FeatureFacade.api
2. Не использовать Api напрямую в DepsImpl, использовать вместо этого FeatureFacade + lazy